### PR TITLE
Chapter2: Reset reader index

### DIFF
--- a/src/main/java/com/manning/nettyinaction/chapter2/EchoServerHandler.java
+++ b/src/main/java/com/manning/nettyinaction/chapter2/EchoServerHandler.java
@@ -23,7 +23,8 @@ public class EchoServerHandler extends
         ByteBuf in = (ByteBuf) msg;
         System.out.println("Server received: " + ByteBufUtil
                 .hexDump(in.readBytes(in.readableBytes())));
-        ctx.write(msg);
+        in.readerIndex(0);
+        ctx.write(in);
     }
 
     @Override


### PR DESCRIPTION
In the Chapter2, EchoServer send empty message. Because bytebuf's reader index is forwarded to the last when printing the bytebuf.
