### PR TITLE
Upgraded NPM boot to a version compatible with 1.7.0u71 or above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 This Repository contains the source-code for all chapters of the [Netty in Action Book](http://manning.com/maurer).
 
 Enjoy and feedback / PR's welcome!
+
+## Pre-requisites
+
+- JDK 1.7.0u71 or better
+- Maven 3.2.3 or better
+
+## Troubleshooting
+
+- If you're hitting a `NoSuchMethodError` when starting chapter 12's SPDY server,
+  edit `pom.xml` and change the version of `npn.boot.version` to one that matches
+  your JDK's version in [this table](http://www.eclipse.org/jetty/documentation/current/npn-chapter.html#npn-versions).

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     </dependencies>
     <properties>
         <npn.version>1.1.0.v20120525</npn.version>
-        <npn.boot.version>1.1.5.v20130313</npn.boot.version>
+        <npn.boot.version>1.1.10.v20150130</npn.boot.version>
         <netty.version>4.0.25.Final</netty.version>
 	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Fixes #14, tested working with:

<pre>
java version "1.7.0_71"
Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)
</pre>
and
<pre>
java version "1.8.0_25"
Java(TM) SE Runtime Environment (build 1.8.0_25-b17)
Java HotSpot(TM) 64-Bit Server VM (build 25.25-b02, mixed mode)
</pre>