### PR TITLE
Update to Netty 4.1.0 Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </modules>
     <properties>
         <junit.version>4.11</junit.version>
-        <netty.version>4.0.31.Final</netty.version>
+        <netty.version>4.1.0.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </modules>
     <properties>
         <junit.version>4.11</junit.version>
-        <netty.version>4.1.0.Final</netty.version>
+        <netty.version>4.1.1.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
As netty was updated to 4.1.0 Final, we can bump the version.

This sort of change allows us to catch up with the latest netty source code.
For example, we can recognise some deprecated methods used in the text sample code if this is the case.
