### PR TITLE
Update behaviors when doing WebSocket send

### DIFF
--- a/chapter12/src/main/resources/index.html
+++ b/chapter12/src/main/resources/index.html
@@ -1,4 +1,5 @@
-<!doctype html>
+<!DOCTYPE html>
+<html>
 <head>
     <meta charset="utf-8">
 
@@ -46,16 +47,13 @@
                         }
 
                         ws.onmessage = function (d) {
-                            log('Response : ' + d.data)
+                            log(d.data)
                         }
 
                         $('#send').click(function () {
                             var msg = $('#msg').val()
-                            $('#msg').val('')
-                            if (ws.send(msg)) {
-                                log('Message sent')
-                            } else {
-                                log('Message not sent')
+                            if (msg.trim()) {
+                                ws.send(msg)
                             }
                         })
 


### PR DESCRIPTION
The return type of send becomes void in the newest [WebSocket API](https://www.w3.org/TR/2011/WD-websockets-20110929/#websocket). So it is of no sense in catching the result, and the message sent will be returned to the onmessage method.