### PR TITLE
User a more terse version of a ByteBuf-String conversion

### DIFF
--- a/chapter2/Client/src/main/java/nia/chapter2/echoclient/EchoClientHandler.java
+++ b/chapter2/Client/src/main/java/nia/chapter2/echoclient/EchoClientHandler.java
@@ -29,11 +29,7 @@ public class EchoClientHandler
      */
     @Override
     public void channelRead0(ChannelHandlerContext ctx, ByteBuf in) {
-        byte[] b = new byte[in.readableBytes()];
-        in.getBytes(0, b, 0, in.readableBytes());
-        String s = new String(b);
-        //System.out.println("Client received: " + ByteBufUtil.hexDump(in) + ":" + s);
-        System.out.println("Client received: " + s);
+        System.out.println("Client received: " + in.toString(CharsetUtil.UTF_8));
     }
 
     /**

--- a/chapter2/Server/src/main/java/nia/chapter2/echoserver/EchoServerHandler.java
+++ b/chapter2/Server/src/main/java/nia/chapter2/echoserver/EchoServerHandler.java
@@ -6,6 +6,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.CharsetUtil;
 
 /**
  * Listing 2.1  of <i>Netty in Action</i>
@@ -18,11 +19,7 @@ public class EchoServerHandler
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         ByteBuf in = (ByteBuf) msg;
-        byte[] b = new byte[in.readableBytes()];
-        in.getBytes(0, b, 0, in.readableBytes());
-        String s = new String(b);
-        //System.out.println("Server received: " + ByteBufUtil.hexDump(in));
-        System.out.println("Server received: " + s);
+        System.out.println("Server received: " + in.toString(CharsetUtil.UTF_8));
         ctx.write(in);
     }
 


### PR DESCRIPTION
We can just use the `ByteBuf#toString` method to convert it to a string
instead creating an intermediary byte array. This also aligns the code
with the book example.