### PR TITLE
Fix the NettyOioServer example

### DIFF
--- a/chapter4/src/main/java/nia/chapter4/NettyOioServer.java
+++ b/chapter4/src/main/java/nia/chapter4/NettyOioServer.java
@@ -34,7 +34,7 @@ public class NettyOioServer {
                         @Override
                         public void channelActive(ChannelHandlerContext ctx)
                             throws Exception {
-                            ctx.write(buf.duplicate()).addListener(ChannelFutureListener.CLOSE);
+                            ctx.writeAndFlush(buf.duplicate()).addListener(ChannelFutureListener.CLOSE);
                         }
                     });
                 }


### PR DESCRIPTION
The code example for `NettyNioServer` doesn't work, because the server
doesn't flush a message wrote to a client and closes the TCP connection
immediately. You can verify that by running a server on a TCP port and
connecting to it via telnet.

The fix is to use the `writeAndFlush` method as described in the book.