### PR TITLE
Fix the package name for chapter 7

### DIFF
--- a/chapter7/src/main/java/nia/chapter7/ScheduleExamples.java
+++ b/chapter7/src/main/java/nia/chapter7/ScheduleExamples.java
@@ -1,4 +1,4 @@
-package nia.chapter15;
+package nia.chapter7;
 
 import io.netty.channel.Channel;
 


### PR DESCRIPTION
The chapter code is located under `/src/main/java/nia/chapter7` directory, but the
package name in the `ScheduleExamples` class is declared as `nia.chapter15`.