### PR TITLE
Use consistent Java version for utils and netty-parent

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -16,7 +16,7 @@
                 <version>3.3</version>
                 <configuration>
                     <source>1.7</source>
-                    <target>1.8</target>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Use the 1.7 target version. The book states the project should be
able to run on a development  environment with JDK7 and looks
like there is no reason why it should not.