### PR TITLE
fix chapter12 index.html always display"message not send"

### DIFF
--- a/chapter12/src/main/resources/index.html
+++ b/chapter12/src/main/resources/index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<html>
 <head>
     <meta charset="utf-8">
 
@@ -52,11 +53,7 @@
                         $('#send').click(function () {
                             var msg = $('#msg').val()
                             $('#msg').val('')
-                            if (ws.send(msg)) {
-                                log('Message sent')
-                            } else {
-                                log('Message not sent')
-                            }
+                            ws.send(msg)
                         })
 
                     } else {


### PR DESCRIPTION
Because WebSocket.send() no return value, it's always display"message not send" even if message sent.
It's unnecessary to check return value from WebSocket.send() and I delete this code.