### PR TITLE
Fix some issues for chapter-13

### DIFF
--- a/chapter13/src/main/java/nia/chapter13/LogEventDecoder.java
+++ b/chapter13/src/main/java/nia/chapter13/LogEventDecoder.java
@@ -25,7 +25,7 @@ public class LogEventDecoder extends MessageToMessageDecoder<DatagramPacket> {
         String filename = data.slice(0, idx)
             .toString(CharsetUtil.UTF_8);
         String logMsg = data.slice(idx + 1,
-            data.readableBytes()).toString(CharsetUtil.UTF_8);
+            data.readableBytes() - idx - 1).toString(CharsetUtil.UTF_8);
         LogEvent event = new LogEvent(datagramPacket.sender(),
             System.currentTimeMillis(), filename, logMsg);
         out.add(event);


### PR DESCRIPTION
```java
    /**
     * Returns a slice of this buffer's sub-region. Modifying the content of
     * the returned buffer or this buffer affects each other's content while
     * they maintain separate indexes and marks.
     * This method does not modify {@code readerIndex} or {@code writerIndex} of
     * this buffer.
     * <p>
     * Also be aware that this method will NOT call {@link #retain()} and so the
     * reference count will NOT be increased.
     */
    public abstract ByteBuf slice(int index, int length);
```
 This method does not modify readerIndex or writerIndex of this buffer.
So we should  change from ：
```java
        String logMsg = data.slice(idx + 1,
            data.readableBytes()).toString(CharsetUtil.UTF_8);
```
to:
```java
        String logMsg = data.slice(idx + 1,
            data.readableBytes() - idx - 1).toString(CharsetUtil.UTF_8);
```
```data.readableBytes() - idx - 1``` will slice a right length, it will work better.