### PR TITLE
WebSocket.send() does not return a boolean.

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -52,11 +52,7 @@
                         $('#send').click(function () {
                             var msg = $('#msg').val()
                             $('#msg').val('')
-                            if (ws.send(msg)) {
-                                log('Message sent')
-                            } else {
-                                log('Message not sent')
-                            }
+                            ws.send(msg)
                         })
 
                     } else {


### PR DESCRIPTION
The assumption in index.html is that the WebSocket.send() method returns a boolean result. That was only true of some versions of Gecko and has been fixed in the current release of Gecko.

See the note here
https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/send#Exceptions_thrown