### PR TITLE
fix IndexOutOfBoundsException in CmdDecoder

### DIFF
--- a/chapter11/src/main/java/nia/chapter11/CmdHandlerInitializer.java
+++ b/chapter11/src/main/java/nia/chapter11/CmdHandlerInitializer.java
@@ -51,7 +51,7 @@ public class CmdHandlerInitializer extends ChannelInitializer<Channel> {
             int index = frame.indexOf(frame.readerIndex(),
                     frame.writerIndex(), SPACE);
             return new Cmd(frame.slice(frame.readerIndex(), index),
-                    frame.slice(index + 1, frame.writerIndex()));
+                    frame.slice(index + 1, frame.writerIndex() - index - 1));
         }
     }
 


### PR DESCRIPTION
The code from the book produces the following exception

`Error evaluating method : 'slice': Method threw 'java.lang.IndexOutOfBoundsException' exception.`

The second argument to slice is the length not the "to index"