### PR TITLE
make channelReadComplete() to echo back the message to client

### DIFF
--- a/chapter2/Server/src/main/java/nia/chapter2/echoserver/EchoServerHandler.java
+++ b/chapter2/Server/src/main/java/nia/chapter2/echoserver/EchoServerHandler.java
@@ -26,7 +26,7 @@ public class EchoServerHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx)
             throws Exception {
-        ctx.writeAndFlush(Unpooled.EMPTY_BUFFER)
+         ctx.writeAndFlush(Unpooled.buffer())
                 .addListener(ChannelFutureListener.CLOSE);
     }
 


### PR DESCRIPTION
As per the book "Netty In Action" > 2.4 Writing an Echo client > Point 3, the client is expected to wait and receive the same message back from the server. Current implementation of ```EchoServerHandler``` doesn't echo back the message to the client. This pull request is to bring the code in sync with the book content.